### PR TITLE
Touchandmouse

### DIFF
--- a/jquery.event.ue.js
+++ b/jquery.event.ue.js
@@ -665,7 +665,7 @@
       case 'touchstart' :
         handler_fn = fnMotionStart;
         event.preventDefault();
-        break;
+      break;
       case 'touchmove'  :
         handler_fn = fnMotionMove;
         event.preventDefault();


### PR DESCRIPTION
'touchstart' is generating mouse events, which results in tap handler being called twice. Disable mouse for touch. 

Not sure if this effects other events. I ran the tests and all seems to work.
